### PR TITLE
Add post schema

### DIFF
--- a/src/IPost.ts
+++ b/src/IPost.ts
@@ -1,0 +1,9 @@
+export interface IPost {
+  key: string;
+  title: string;
+  author?: string;
+  date?: Date;
+  body?: string;
+  category?: string;
+  tags?: string[];
+}

--- a/src/IPostProvider.ts
+++ b/src/IPostProvider.ts
@@ -1,0 +1,6 @@
+import { IPost } from './IPost';
+
+export interface IPostProvider {
+  list(): Promise<IPost[]>;
+  get(key: string): Promise<IPost>;
+}

--- a/src/Renderer.ts
+++ b/src/Renderer.ts
@@ -1,8 +1,39 @@
 import Handlebars from 'handlebars';
+import { IPostProvider } from 'IPostProvider';
 
 export class Renderer {
-  public static async render<T>(template: string, content: T): Promise<string> {
+  private postProvider: IPostProvider;
+
+  constructor(postProvider: IPostProvider) {
+    this.postProvider = postProvider;
+    Handlebars.registerHelper('formatDate', this.formatDate)
+  }
+
+  public async render<T>(template: string, content: T): Promise<string> {
     const compiled = Handlebars.compile(template);
     return compiled(content);
+  }
+
+  public async renderList<T>(template: string): Promise<string> {
+    const posts = await this.postProvider.list();
+    const compiled = Handlebars.compile(template);
+
+    return compiled({ posts });
+  }
+
+  public async renderPost<T>(key: string, template: string): Promise<string> {
+    const post = await this.postProvider.get(key);
+    const compiled = Handlebars.compile(template);
+
+    return compiled(post);
+  }
+
+  public formatDate(date: Date) {
+    const options: Intl.DateTimeFormatOptions = { 
+      year: 'numeric', 
+      month: 'short', 
+      day: 'numeric',
+    };
+    return (new Intl.DateTimeFormat('en-US', options)).format(date);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
+export * from './IPost';
+export * from './IPostProvider';
 export * from './Renderer';

--- a/test/unit/Renderer.spec.ts
+++ b/test/unit/Renderer.spec.ts
@@ -1,9 +1,115 @@
-import { Renderer } from '../../src/index';
+import { IPostProvider, Renderer } from '../../src/index';
 
 describe('Renderer', () => {
-  it('should render template with content', async() => {
-    const result = await Renderer.render('Handlebars <b>{{doesWhat}}</b> compiled!', { doesWhat: 'rocks!' });
+  describe('render()', () => {
+    it('should render template with content', async() => {
+      const postProvider: IPostProvider = {
+        list: () => {
+          return Promise.resolve([]);
+        },
+        get: (key) => {
+          return Promise.resolve({ key, title: 'foo' });
+        },
+      };
 
-    expect(result).toBe('Handlebars <b>rocks!</b> compiled!');
+      const renderer = new Renderer(postProvider);
+      const result = await renderer.render('Handlebars <b>{{doesWhat}}</b> compiled!', { doesWhat: 'rocks!' });
+
+      expect(result).toBe('Handlebars <b>rocks!</b> compiled!');
+    });
+  });
+
+  describe('renderList()', () => {
+    it('should render template with all post fields', async() => {
+      const postProvider: IPostProvider = {
+        list: () => {
+          return Promise.resolve([
+            {
+              key: 'post-1',
+              title: 'Blog post 1',
+              author: 'Bloggy Blogerton',
+              date: new Date(2000, 0, 1),
+              body: 'This is a blog post',
+              category: 'Posts about Blogs',
+              tags: [ 'blog', 'post' ],
+            },
+            {
+              key: 'post-2',
+              title: 'Blog post 2',
+              author: 'Bloggy Blogerton',
+              date: new Date(2000, 0, 2),
+              body: 'This is another blog post',
+              category: 'Posts about Blogs',
+              tags: [ 'blog', 'post' ],
+            }
+          ]);
+        },
+        get: (key) => {
+          return Promise.resolve({ key, title: 'foo' });
+        },
+      };
+
+      const renderer = new Renderer(postProvider);
+
+      const template = '{{#posts}}{{key}}:{{title}}:{{author}}:{{formatDate date}}::{{body}}/{{category}}[{{#tags}}{{this}},{{/tags}}]{{/posts}}';
+      const result = await renderer.renderList(template);
+
+      expect(result).toBe('post-1:Blog post 1:Bloggy Blogerton:Jan 1, 2000::This is a blog post/Posts about Blogs[blog,post,]post-2:Blog post 2:Bloggy Blogerton:Jan 2, 2000::This is another blog post/Posts about Blogs[blog,post,]');
+    });
+
+    it('should render list with minimum post fields', async() => {
+      const postProvider: IPostProvider = {
+        list: () => {
+          return Promise.resolve([
+            {
+              key: 'post-1',
+              title: 'Blog post 1',
+            },
+            {
+              key: 'post-2',
+              title: 'Blog post 2',
+            }
+          ]);
+        },
+        get: (key) => {
+          return Promise.resolve({ key, title: 'foo' });
+        },
+      };
+
+      const renderer = new Renderer(postProvider);
+
+      const template = '<ul>{{#posts}}<li><a href="/post/{{key}}">{{title}}</a></li>{{/posts}}</ul>';
+      const result = await renderer.renderList(template);
+
+      expect(result).toBe('<ul><li><a href="/post/post-1">Blog post 1</a></li><li><a href="/post/post-2">Blog post 2</a></li></ul>');
+    });
+  });
+
+  describe('renderPost()', () => {
+    it('should render a single post', async() => {
+      const postProvider: IPostProvider = {
+        list: () => {
+          return Promise.resolve([]);
+        },
+        get: (key) => {
+          return Promise.resolve({
+            key,
+            title: 'Blog post 1',
+            author: 'Bloggy Blogerton',
+            date: new Date(2000, 0, 1),
+            body: 'This is a blog post',
+            category: 'Posts about Blogs',
+            tags: [ 'blog', 'post' ],
+          });
+        },
+      };
+
+      const renderer = new Renderer(postProvider);
+
+      const template = '{{key}}:{{title}}:{{author}}:{{formatDate date}}::{{body}}/{{category}}[{{#tags}}{{this}},{{/tags}}]';
+      const result = await renderer.renderPost('post-1', template);
+
+      expect(result).toBe('post-1:Blog post 1:Bloggy Blogerton:Jan 1, 2000::This is a blog post/Posts about Blogs[blog,post,]');
+    });
   });
 });


### PR DESCRIPTION
Add types for handling posts and logic to render posts in the renderer:

- Add new `IPost` interface with the schema for a post
- Add new `IPostProvider` interface to define methods for getting a list of posts and a single post
- Add new `renderList` and `renderPost` methods to the `Renderer` class